### PR TITLE
Validations for multiple iframes for reloading google document

### DIFF
--- a/modules/document-viewer.component.html
+++ b/modules/document-viewer.component.html
@@ -13,7 +13,7 @@
 <ng-container *ngIf="externalViewer">
     <iframe
         *ngIf="fullUrl && disableContent === 'none'"
-        id="iframe"
+        id="doc-iframe"
         frameBorder="0"
         [src]="fullUrl"
     ></iframe>
@@ -30,7 +30,7 @@
         </div>
         <iframe
             *ngIf="fullUrl"
-            id="iframe"
+            id="doc-iframe"
             frameBorder="0"
             [src]="fullUrl"
         ></iframe>

--- a/modules/document-viewer.component.html
+++ b/modules/document-viewer.component.html
@@ -32,7 +32,7 @@
         <iframe
             *ngIf="fullUrl"
             #iframe
-            id="doc-iframe"
+            id="iframe"
             frameBorder="0"
             [src]="fullUrl"
         ></iframe>

--- a/modules/document-viewer.component.ts
+++ b/modules/document-viewer.component.ts
@@ -127,7 +127,7 @@ export class NgxDocViewerComponent implements OnChanges, OnDestroy {
                 // hack to reload iframe if it's not loaded.
                 // would maybe be better to use view.officeapps.live.com but seems not to work with sas token.
                 if (this.configuredViewer === 'google' && this.googleCheckContentLoaded) {
-                  console.log(this.this.configuredViewer, this.googleCheckContentLoaded);
+                  console.log(this.configuredViewer, this.googleCheckContentLoaded);
                   console.log('great');
                     this.ngZone.runOutsideAngular(() => {
                         let iframe = document.querySelector('iframe');

--- a/modules/document-viewer.component.ts
+++ b/modules/document-viewer.component.ts
@@ -127,6 +127,8 @@ export class NgxDocViewerComponent implements OnChanges, OnDestroy {
                 // hack to reload iframe if it's not loaded.
                 // would maybe be better to use view.officeapps.live.com but seems not to work with sas token.
                 if (this.configuredViewer === 'google' && this.googleCheckContentLoaded) {
+                  console.log(this.this.configuredViewer, this.googleCheckContentLoaded);
+                  console.log('great');
                     this.ngZone.runOutsideAngular(() => {
                         let iframe = document.querySelector('iframe');
                         this.checkIFrame(iframe);

--- a/modules/document-viewer.component.ts
+++ b/modules/document-viewer.component.ts
@@ -127,10 +127,8 @@ export class NgxDocViewerComponent implements OnChanges, OnDestroy {
                 // hack to reload iframe if it's not loaded.
                 // would maybe be better to use view.officeapps.live.com but seems not to work with sas token.
                 if (this.configuredViewer === 'google' && this.googleCheckContentLoaded) {
-                  console.log(this.configuredViewer, this.googleCheckContentLoaded);
-                  console.log('great');
                     this.ngZone.runOutsideAngular(() => {
-                        let iframe = document.querySelector('iframe');
+                        let iframe = this.findDocumentViewerIframe();
                         this.checkIFrame(iframe);
                         // if it's not loaded after the googleIntervalCheck, then open load again.
                         this.checkIFrameSubscription = interval(this.googleCheckInterval)
@@ -138,7 +136,7 @@ export class NgxDocViewerComponent implements OnChanges, OnDestroy {
                                 take(Math.round(this.googleCheckInterval === 0 ? 0 : 20000 / this.googleCheckInterval)))
                             .subscribe(() => {
                                 if (iframe == null) {
-                                    iframe = document.querySelector('iframe');
+                                    iframe = this.findDocumentViewerIframe();
                                     this.checkIFrame(iframe);
                                 }
                                 this.reloadIFrame(iframe);
@@ -153,6 +151,19 @@ export class NgxDocViewerComponent implements OnChanges, OnDestroy {
             }
         }
     }
+
+    findDocumentViewerIframe(): HTMLIFrameElement {
+        let docViewerIframe;
+        document.querySelectorAll('iframe').forEach(
+            iframeItem => {
+                if (iframeItem && iframeItem.id == 'doc-iframe') {
+                    docViewerIframe = iframeItem;
+                }
+            }
+        );
+        return docViewerIframe;
+    }
+
     checkIFrame(iframe: HTMLIFrameElement) {
         if (iframe) {
             iframe.onload = () => {

--- a/modules/document-viewer.component.ts
+++ b/modules/document-viewer.component.ts
@@ -153,18 +153,6 @@ export class NgxDocViewerComponent implements OnChanges, OnDestroy {
         }
     }
 
-    findDocumentViewerIframe(): HTMLIFrameElement {
-        let docViewerIframe;
-        document.querySelectorAll('iframe').forEach(
-            iframeItem => {
-                if (iframeItem && iframeItem.id == 'doc-iframe') {
-                    docViewerIframe = iframeItem;
-                }
-            }
-        );
-        return docViewerIframe;
-    }
-
     checkIFrame(iframe: HTMLIFrameElement) {
         if (iframe) {
             iframe.onload = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "ngx-doc-viewer",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
Doc viewer won't work if there are multiple iframes. Cause reloading works based on `iframe.src = iframe.src` and it replaces src of some other iframe.

So added validations to check whether it's updating src of document viewer iframe.